### PR TITLE
Adds deprecation warning and pushes users to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Deprecation warning / new version
+Looking for a more robust and up-to-date version of this Gatsby Segment plugin?
+The following plugin has a few additional features and will be kept up to date as Gatsby migrates to v2:
+- [npm module](https://www.npmjs.com/package/gatsby-plugin-segment-js)
+- [github repo](https://github.com/benjaminhoffman/gatsby-plugin-segment-js)
+
+Also note this repo will be deprecated in the near future in favor of the one above.  Currently, we cannot guarantee this repo works with Gatsby v2.
+
 # gatsby-plugin-segment
 
 A [Gatsby](https://www.gatsbyjs.org) plugin for [Segment](https://segment.com/).


### PR DESCRIPTION
@stephenmathieson hope this is okay?  i'm starting to migrate all my gatsby plugins over to Gatsby v2 compatibility now that they have a release candidate for v2.  My hope is to deprecate this (your) segment plugin and solely maintain mine.  hope that's chill!

if you _lgtm_ or whatever, i can merge and publish a new version. 🌮 